### PR TITLE
add .gitignore tempate for JetBrains IDE things like .idea and so on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,50 @@ buildNumber.properties
 .project
 .classpath
 .settings
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+


### PR DESCRIPTION
Hi, Gordon.

Big Congrats on successful debuit of the ADT project. I hope that the ADT take the throne of 'ALMIGHTY' data handling tools and is adopted worldwide. Keep up the good work~! 

Would you mind if I ask you to take a look at my PR about .gitignore? LOL

IMHO, it's quite helpful for users based on JetBrains Dev. Environment, such as IntelliJ if .gitignore of the project has a few entries like the .idea subdirectory or .iml files.
